### PR TITLE
scalable form submission schema, with docs

### DIFF
--- a/src/db/schema/form_submissions.schema.ts
+++ b/src/db/schema/form_submissions.schema.ts
@@ -1,0 +1,37 @@
+// Guide to utilize this schema
+// this schema is only but a reference to the real form data tables like dispatch_form, trip_tickets, etc.
+// so we create a new table for each forms we have, and then add it to the formTypeEnum below,
+// then we use the reference_id here to point to the id of the associated form type
+// example use case would a submission for trip_tickets
+// when we submit a form first we create an entry to the trip_tickets table
+// then after the trip_tickets table we will create a new entry in this table
+// the form type will be trip_tickets, reference_id will be the id from the created trip_tickets data
+
+import { pgEnum, pgTable, timestamp, uuid } from "drizzle-orm/pg-core";
+import { createInsertSchema, createUpdateSchema } from "drizzle-zod";
+import { usersTable } from "./users.schema";
+
+const formTypeEnum = pgEnum("form_type", ["dispatch", "trip_tickets", 'census']);
+const formStatusEnum = pgEnum("status", ["pending", "approved", "rejected"]);
+
+export const formSubmissions = pgTable("form_submissions", {
+  id: uuid().primaryKey().defaultRandom(),
+
+  form_type: formTypeEnum().notNull(), // form type (dispatch, trip_tickets, census, etc.)
+  reference_id: uuid().notNull(), // point to the id of the associated form type
+  status: formStatusEnum().notNull().default('pending'), // status for the form submission
+
+  submitted_by: uuid().references(() => usersTable.id, { onDelete: 'set null' }), // user who submitted the form (staff)
+  reviewed_by: uuid().references(() => usersTable.id, { onDelete: 'set null' }), // user who review it (admin)
+
+  created_at: timestamp().notNull().defaultNow(),
+  updated_at: timestamp().notNull().defaultNow(),
+}).enableRLS();
+
+// use this for type inference for arguments
+export type FormSubmission = typeof formSubmissions.$inferSelect;
+export type NewFormSubmission = typeof formSubmissions.$inferInsert;
+
+// use this for validating data in the server
+export const NewFormSubmissionSchema = createInsertSchema(formSubmissions);
+export const UpdateFormSubmissionSchema = createUpdateSchema(formSubmissions);


### PR DESCRIPTION
This pull request introduces a new database schema for managing form submissions in the `src/db/schema/form_submissions.schema.ts` file. The schema is designed to standardize the handling of various form types, including `dispatch`, `trip_tickets`, and `census`, and provides mechanisms for tracking submission statuses and relationships to users.

### Database schema additions:

* Added a new table `form_submissions` with fields for `form_type`, `reference_id`, `status`, `submitted_by`, `reviewed_by`, `created_at`, and `updated_at`. This table acts as a reference for form submissions across different form types.
* Defined two enums: `formTypeEnum` for categorizing form types (`dispatch`, `trip_tickets`, `census`) and `formStatusEnum` for tracking submission statuses (`pending`, `approved`, `rejected`).
* Enabled row-level security (RLS) on the `form_submissions` table to enhance data protection and access control.

### Type inference and validation:

* Added type definitions `FormSubmission` and `NewFormSubmission` for type inference when working with the schema programmatically.
* Created validation schemas `NewFormSubmissionSchema` and `UpdateFormSubmissionSchema` using `drizzle-zod` for server-side data validation.