### PR TITLE
Perf/forms

### DIFF
--- a/src/actions/form_submissions.action.ts
+++ b/src/actions/form_submissions.action.ts
@@ -60,10 +60,26 @@ export async function deleteFormSubmission(id: string) {
   return deleted;
 }
 
+export async function fetchReferenceForm(
+  formType: string,
+  referenceId: string
+): Promise<any> {
+  try {
+    const query = sql.raw(
+      `SELECT * FROM "${formType}" WHERE id = '${referenceId}'`
+    );
+
+    const result = await db.execute(query);
+    return result[0] || null;
+  } catch (error) {
+    console.error(`Failed to fetch reference form: ${error}`);
+    return null;
+  }
+}
+
 export type PendingFormType = {
   form_submissions: FormSubmission;
   submitted_by: User;
-  referenceForm: Record<string, unknown>;
 };
 export async function listPendingForms(): Promise<PendingFormType[]> {
   const submittedByQuery = db
@@ -79,20 +95,7 @@ export async function listPendingForms(): Promise<PendingFormType[]> {
     .orderBy(desc(formSubmissionsTable.created_at))
     .innerJoinLateral(submittedByQuery, sql`true`);
 
-  const forms = [];
-  for (const form of pendingSubmissions) {
-    const formType = form.form_submissions.form_type;
-    const referenceId = form.form_submissions.reference_id;
-
-    const query = sql.raw(
-      `SELECT * FROM "${formType}" WHERE id = '${referenceId}'`
-    );
-
-    const referenceForm = await db.execute(query);
-    forms.push({ ...form, referenceForm: referenceForm[0] || null });
-  }
-
-  return forms;
+  return pendingSubmissions;
 }
 
 export interface ReviewedFormType extends PendingFormType {
@@ -110,7 +113,7 @@ export async function listReviewedForms(): Promise<ReviewedFormType[]> {
     .where(eq(usersTable.id, formSubmissionsTable.reviewed_by))
     .as('reviewed_by');
 
-  const pendingSubmissions = await db
+  const reviewedSubmissions = await db
     .select()
     .from(formSubmissionsTable)
     .where(
@@ -123,24 +126,12 @@ export async function listReviewedForms(): Promise<ReviewedFormType[]> {
     .innerJoinLateral(submittedByQuery, sql`true`)
     .innerJoinLateral(reviewedByQuery, sql`true`);
 
-  const forms = [];
-  for (const form of pendingSubmissions) {
-    const formType = form.form_submissions.form_type;
-    const referenceId = form.form_submissions.reference_id;
-
-    const query = sql.raw(
-      `SELECT * FROM "${formType}" WHERE id = '${referenceId}'`
-    );
-
-    const referenceForm = await db.execute(query);
-    forms.push({ ...form, referenceForm: referenceForm[0] || null });
-  }
-
-  return forms;
+  return reviewedSubmissions;
 }
 
-export interface AllFormType extends PendingFormType {
-  reviewed_by?: User | null;
+export interface AllFormType {
+  form_submissions: FormSubmission;
+  submitted_by: User;
 }
 export async function listAllForms(): Promise<AllFormType[]> {
   const submittedByQuery = db
@@ -148,31 +139,12 @@ export async function listAllForms(): Promise<AllFormType[]> {
     .from(usersTable)
     .where(eq(usersTable.id, formSubmissionsTable.submitted_by))
     .as('submitted_by');
-  const reviewedByQuery = db
-    .select()
-    .from(usersTable)
-    .where(eq(usersTable.id, formSubmissionsTable.reviewed_by))
-    .as('reviewed_by');
 
-  const pendingSubmissions = await db
+  const forms = await db
     .select()
     .from(formSubmissionsTable)
     .orderBy(desc(formSubmissionsTable.created_at))
     .innerJoinLateral(submittedByQuery, sql`true`)
-    .leftJoinLateral(reviewedByQuery, sql`true`);
-
-  const forms = [];
-  for (const form of pendingSubmissions) {
-    const formType = form.form_submissions.form_type;
-    const referenceId = form.form_submissions.reference_id;
-
-    const query = sql.raw(
-      `SELECT * FROM "${formType}" WHERE id = '${referenceId}'`
-    );
-
-    const referenceForm = await db.execute(query);
-    forms.push({ ...form, referenceForm: referenceForm[0] || null });
-  }
 
   return forms;
 }

--- a/src/app/(protected)/(admin)/forms/columns.tsx
+++ b/src/app/(protected)/(admin)/forms/columns.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { AllFormType } from '@/actions/form_submissions.action';
 import PendingFormAction from '@/components/table-action/PendingFormAction';
 import ReviewedFormAction from '@/components/table-action/ReviewedFormAction';
 import { DataTableColumnHeader } from '@/components/table/data-table-column-header';
 import { ColumnDef } from '@tanstack/react-table';
 import { formatDate } from 'date-fns';
 import { Check, CircleX, ClockFading } from 'lucide-react';
+import { AllFormType } from '../../../../actions/form_submissions.action';
 import { allFormStatus } from './data';
 
 export const columns: ColumnDef<AllFormType>[] = [
@@ -108,12 +108,10 @@ export const columns: ColumnDef<AllFormType>[] = [
       row.original.form_submissions.status === 'pending' ? (
         <PendingFormAction
           formSubmission={row.original.form_submissions}
-          formData={row.original.referenceForm}
         />
       ) : (
         <ReviewedFormAction
           formSubmission={row.original.form_submissions}
-          formData={row.original.referenceForm}
         />
       ),
   },

--- a/src/app/(protected)/(admin)/forms/columns.tsx
+++ b/src/app/(protected)/(admin)/forms/columns.tsx
@@ -12,9 +12,8 @@ import { allFormStatus } from './data';
 export const columns: ColumnDef<ListFormType>[] = [
   {
     id: 'form_type',
-    enableColumnFilter: true,
-    accessorFn: (row) =>
-      `${row.form_submissions.form_type.split('_').join(' ')}`,
+    enableGlobalFilter: false,
+    accessorFn: (row) => row.form_submissions.form_type,
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Form Type" />
     ),
@@ -43,7 +42,6 @@ export const columns: ColumnDef<ListFormType>[] = [
     id: 'status',
     accessorFn: (row) => row.form_submissions.status,
     enableGlobalFilter: false,
-    enableColumnFilter: true,
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Status" />
     ),

--- a/src/app/(protected)/(admin)/forms/columns.tsx
+++ b/src/app/(protected)/(admin)/forms/columns.tsx
@@ -1,15 +1,15 @@
 'use client';
 
+import { ListFormType } from '@/actions/form_submissions.action';
 import PendingFormAction from '@/components/table-action/PendingFormAction';
 import ReviewedFormAction from '@/components/table-action/ReviewedFormAction';
 import { DataTableColumnHeader } from '@/components/table/data-table-column-header';
 import { ColumnDef } from '@tanstack/react-table';
 import { formatDate } from 'date-fns';
 import { Check, CircleX, ClockFading } from 'lucide-react';
-import { AllFormType } from '../../../../actions/form_submissions.action';
 import { allFormStatus } from './data';
 
-export const columns: ColumnDef<AllFormType>[] = [
+export const columns: ColumnDef<ListFormType>[] = [
   {
     id: 'form_type',
     enableColumnFilter: true,

--- a/src/app/(protected)/(admin)/forms/page.tsx
+++ b/src/app/(protected)/(admin)/forms/page.tsx
@@ -1,7 +1,7 @@
 import { listAllForms } from '@/actions/form_submissions.action';
 import { DataTable } from '@/components/table/data-table';
 import { columns } from './columns';
-import { allFormStatus } from './data';
+import { allFormStatus, formTypes } from './data';
 
 const AllFormsPage = async () => {
   const data = await listAllForms();
@@ -19,9 +19,10 @@ const AllFormsPage = async () => {
       <DataTable
         columns={columns}
         data={data}
-        searchPlaceholder="Filter form types and submitted by..."
+        searchPlaceholder="Filter submitted by..."
         filters={[
           { columnKey: 'status', title: 'Status', options: allFormStatus },
+          { columnKey: 'form_type', title: 'Form Type', options: formTypes },
         ]}
       />
     </>

--- a/src/app/(protected)/(admin)/forms/pending/columns.tsx
+++ b/src/app/(protected)/(admin)/forms/pending/columns.tsx
@@ -9,9 +9,9 @@ import { ClockFading } from 'lucide-react';
 
 export const columns: ColumnDef<ListFormType>[] = [
   {
-    id: 'Form Type',
-    accessorFn: (row) =>
-      `${row.form_submissions.form_type.split('_').join(' ')}`,
+    id: 'form_type',
+    accessorFn: (row) => row.form_submissions.form_type,
+    enableGlobalFilter: false,
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Form Type" />
     ),
@@ -21,6 +21,9 @@ export const columns: ColumnDef<ListFormType>[] = [
           {row.original.form_submissions.form_type.split('_').join(' ')}
         </span>
       );
+    },
+    filterFn: (row, id, value) => {
+      return value.includes(row.getValue(id));
     },
   },
   {
@@ -66,9 +69,7 @@ export const columns: ColumnDef<ListFormType>[] = [
     id: 'Action',
     enableGlobalFilter: false,
     cell: ({ row }) => (
-      <PendingFormAction
-        formSubmission={row.original.form_submissions}
-      />
+      <PendingFormAction formSubmission={row.original.form_submissions} />
     ),
   },
 ];

--- a/src/app/(protected)/(admin)/forms/pending/columns.tsx
+++ b/src/app/(protected)/(admin)/forms/pending/columns.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { PendingFormType } from '@/actions/form_submissions.action';
+import { ListFormType } from '@/actions/form_submissions.action';
 import PendingFormAction from '@/components/table-action/PendingFormAction';
 import { DataTableColumnHeader } from '@/components/table/data-table-column-header';
 import { ColumnDef } from '@tanstack/react-table';
 import { formatDate } from 'date-fns';
 import { ClockFading } from 'lucide-react';
 
-export const columns: ColumnDef<PendingFormType>[] = [
+export const columns: ColumnDef<ListFormType>[] = [
   {
     id: 'Form Type',
     accessorFn: (row) =>

--- a/src/app/(protected)/(admin)/forms/pending/columns.tsx
+++ b/src/app/(protected)/(admin)/forms/pending/columns.tsx
@@ -68,7 +68,6 @@ export const columns: ColumnDef<PendingFormType>[] = [
     cell: ({ row }) => (
       <PendingFormAction
         formSubmission={row.original.form_submissions}
-        formData={row.original.referenceForm}
       />
     ),
   },

--- a/src/app/(protected)/(admin)/forms/pending/page.tsx
+++ b/src/app/(protected)/(admin)/forms/pending/page.tsx
@@ -1,5 +1,6 @@
 import { listPendingForms } from '@/actions/form_submissions.action';
 import { DataTable } from '@/components/table/data-table';
+import { formTypes } from '../data';
 import { columns } from './columns';
 
 const PendingFormsPage = async () => {
@@ -18,7 +19,8 @@ const PendingFormsPage = async () => {
       <DataTable
         columns={columns}
         data={data}
-        searchPlaceholder="Filter form types and submitted by..."
+        searchPlaceholder="Filter submitted by..."
+        filters={[{ columnKey: 'form_type', title: 'Form Type', options: formTypes }]}
       />
     </>
   );

--- a/src/app/(protected)/(admin)/forms/reviewed/columns.tsx
+++ b/src/app/(protected)/(admin)/forms/reviewed/columns.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { ReviewedFormType } from '@/actions/form_submissions.action';
+import { ListFormType } from '@/actions/form_submissions.action';
+import ReviewedFormAction from '@/components/table-action/ReviewedFormAction';
 import { DataTableColumnHeader } from '@/components/table/data-table-column-header';
 import { ColumnDef } from '@tanstack/react-table';
 import { formatDate } from 'date-fns';
 import { Check, CircleX } from 'lucide-react';
-import ReviewedFormAction from '@/components/table-action/ReviewedFormAction';
 import { reviewedFormStatus } from '../data';
 
-export const columns: ColumnDef<ReviewedFormType>[] = [
+export const columns: ColumnDef<ListFormType>[] = [
   {
     id: 'Form Type',
     accessorFn: (row) =>

--- a/src/app/(protected)/(admin)/forms/reviewed/columns.tsx
+++ b/src/app/(protected)/(admin)/forms/reviewed/columns.tsx
@@ -98,7 +98,6 @@ export const columns: ColumnDef<ReviewedFormType>[] = [
     cell: ({ row }) => (
       <ReviewedFormAction
         formSubmission={row.original.form_submissions}
-        formData={row.original.referenceForm}
       />
     ),
   },

--- a/src/app/(protected)/(admin)/forms/reviewed/columns.tsx
+++ b/src/app/(protected)/(admin)/forms/reviewed/columns.tsx
@@ -10,9 +10,9 @@ import { reviewedFormStatus } from '../data';
 
 export const columns: ColumnDef<ListFormType>[] = [
   {
-    id: 'Form Type',
-    accessorFn: (row) =>
-      `${row.form_submissions.form_type.split('_').join(' ')}`,
+    id: 'form_type',
+    accessorFn: (row) => row.form_submissions.form_type,
+    enableGlobalFilter: false,
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Form Type" />
     ),
@@ -22,6 +22,9 @@ export const columns: ColumnDef<ListFormType>[] = [
           {row.original.form_submissions.form_type.split('_').join(' ')}
         </span>
       );
+    },
+    filterFn: (row, id, value) => {
+      return value.includes(row.getValue(id));
     },
   },
   {
@@ -38,7 +41,6 @@ export const columns: ColumnDef<ListFormType>[] = [
     id: 'status',
     accessorFn: (row) => row.form_submissions.status,
     enableGlobalFilter: false,
-    enableColumnFilter: true,
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Status" />
     ),
@@ -96,9 +98,7 @@ export const columns: ColumnDef<ListFormType>[] = [
     id: 'Action',
     enableGlobalFilter: false,
     cell: ({ row }) => (
-      <ReviewedFormAction
-        formSubmission={row.original.form_submissions}
-      />
+      <ReviewedFormAction formSubmission={row.original.form_submissions} />
     ),
   },
 ];

--- a/src/app/(protected)/(admin)/forms/reviewed/page.tsx
+++ b/src/app/(protected)/(admin)/forms/reviewed/page.tsx
@@ -1,6 +1,6 @@
 import { listReviewedForms } from '@/actions/form_submissions.action';
 import { DataTable } from '@/components/table/data-table';
-import { reviewedFormStatus } from '../data';
+import { formTypes, reviewedFormStatus } from '../data';
 import { columns } from './columns';
 
 const ReviewedFormsPage = async () => {
@@ -19,9 +19,10 @@ const ReviewedFormsPage = async () => {
       <DataTable
         columns={columns}
         data={data}
-        searchPlaceholder="Filter form types and submitted by..."
+        searchPlaceholder="Filter submitted by..."
         filters={[
           { columnKey: 'status', title: 'Status', options: reviewedFormStatus },
+          { columnKey: 'form_type', title: 'Form Type', options: formTypes },
         ]}
       />
     </>

--- a/src/app/(protected)/(admin)/forms/reviewed/page.tsx
+++ b/src/app/(protected)/(admin)/forms/reviewed/page.tsx
@@ -1,7 +1,7 @@
 import { listReviewedForms } from '@/actions/form_submissions.action';
 import { DataTable } from '@/components/table/data-table';
-import { columns } from './columns';
 import { reviewedFormStatus } from '../data';
+import { columns } from './columns';
 
 const ReviewedFormsPage = async () => {
   const data = await listReviewedForms();

--- a/src/components/forms/EmailForm.tsx
+++ b/src/components/forms/EmailForm.tsx
@@ -21,7 +21,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { FileText, Loader } from 'lucide-react';
-import { FormType } from '../../db/schema/form_submissions.schema';
+import { FormSubmission } from '../../db/schema/form_submissions.schema';
 import { capitalizeString } from '../../utils';
 import { generatePdf } from '../../utils/pdf_util';
 
@@ -34,8 +34,7 @@ interface EmailFormProps {
     text: string;
   }) => void;
   onOpenChange: (open: boolean) => void;
-  formType: FormType;
-  formData?: any;
+  formSubmission: FormSubmission
 }
 
 const formSchema = z.object({
@@ -50,8 +49,7 @@ const EmailForm = ({
   loading,
   onSubmit,
   onOpenChange,
-  formType,
-  formData,
+  formSubmission
 }: EmailFormProps) => {
   const form = useForm({
     resolver: zodResolver(formSchema),
@@ -77,7 +75,7 @@ const EmailForm = ({
       <DialogContent aria-disabled={loading}>
         <DialogHeader>
           <DialogTitle>
-            Send Email with PDF Attachment - {capitalizeString(formType, '_')}
+            Send Email with PDF Attachment - {capitalizeString(formSubmission.form_type, '_')}
           </DialogTitle>
           <DialogDescription></DialogDescription>
         </DialogHeader>
@@ -141,13 +139,13 @@ const EmailForm = ({
                 type="button"
                 variant="outline"
                 className="flex items-center justify-start gap-2 border rounded-md p-2 w-full"
-                onClick={() => generatePdf(formType, formData)}
+                onClick={() => generatePdf(formSubmission)}
                 disabled={loading}
               >
                 <div className="flex items-center text-gray-500">
                   <FileText className="h-5 w-5 mr-2" />
                   <span className="text-sm">
-                    PDF Attached - {capitalizeString(formType, '_')}
+                    PDF Attached - {capitalizeString(formSubmission.form_type, '_')}
                   </span>
                 </div>
               </Button>

--- a/src/components/table-action/PendingFormAction.tsx
+++ b/src/components/table-action/PendingFormAction.tsx
@@ -35,10 +35,9 @@ import { Separator } from '../ui/separator';
 
 interface Props {
   formSubmission: FormSubmission;
-  formData: any;
 }
 
-const PendingFormAction = ({ formSubmission, formData }: Props) => {
+const PendingFormAction = ({ formSubmission }: Props) => {
   const { user } = useAuth();
   const [openEmailModal, setOpenEmailModal] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -88,8 +87,7 @@ const PendingFormAction = ({ formSubmission, formData }: Props) => {
     setLoading(true);
     try {
       const pdfBuffer = await generatePdf(
-        formSubmission.form_type,
-        formData,
+        formSubmission,
         true
       );
 
@@ -121,7 +119,7 @@ const PendingFormAction = ({ formSubmission, formData }: Props) => {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuItem
-            onClick={() => generatePdf(formSubmission.form_type, formData)}
+            onClick={() => generatePdf(formSubmission)}
           >
             View Form Details
           </DropdownMenuItem>
@@ -216,8 +214,7 @@ const PendingFormAction = ({ formSubmission, formData }: Props) => {
         loading={loading}
         onSubmit={handleSendEmail}
         onOpenChange={setOpenEmailModal}
-        formType={formSubmission.form_type}
-        formData={formData}
+        formSubmission={formSubmission}
       />
     </>
   );

--- a/src/components/table-action/ReviewedFormAction.tsx
+++ b/src/components/table-action/ReviewedFormAction.tsx
@@ -17,21 +17,20 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { MoreHorizontal } from 'lucide-react';
+import { useState } from 'react';
 import { toast } from 'sonner';
+import { sendEmailWithPdf } from '../../actions/email.action';
 import { deleteFormSubmission } from '../../actions/form_submissions.action';
 import { FormSubmission } from '../../db/schema/form_submissions.schema';
 import { generatePdf } from '../../utils/pdf_util';
-import { Separator } from '../ui/separator';
-import { sendEmailWithPdf } from '../../actions/email.action';
 import EmailForm from '../forms/EmailForm';
-import { useState } from 'react';
+import { Separator } from '../ui/separator';
 
 interface Props {
   formSubmission: FormSubmission;
-  formData: any;
 }
 
-const ReviewedFormAction = ({ formSubmission, formData }: Props) => {
+const ReviewedFormAction = ({ formSubmission }: Props) => {
   const [openEmailModal, setOpenEmailModal] = useState(false);
   const [loading, setLoading] = useState(false);
 
@@ -55,11 +54,7 @@ const ReviewedFormAction = ({ formSubmission, formData }: Props) => {
   }) => {
     setLoading(true);
     try {
-      const pdfBuffer = await generatePdf(
-        formSubmission.form_type,
-        formData,
-        true
-      );
+      const pdfBuffer = await generatePdf(formSubmission, true);
 
       await sendEmailWithPdf(pdfBuffer!, {
         to: emailOptions.to,
@@ -88,9 +83,7 @@ const ReviewedFormAction = ({ formSubmission, formData }: Props) => {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem
-            onClick={() => generatePdf(formSubmission.form_type, formData)}
-          >
+          <DropdownMenuItem onClick={() => generatePdf(formSubmission)}>
             View Form Details
           </DropdownMenuItem>
           <DropdownMenuItem onClick={() => setOpenEmailModal(true)}>
@@ -135,8 +128,7 @@ const ReviewedFormAction = ({ formSubmission, formData }: Props) => {
         loading={loading}
         onSubmit={handleSendEmail}
         onOpenChange={setOpenEmailModal}
-        formType={formSubmission.form_type}
-        formData={formData}
+        formSubmission={formSubmission}
       />
     </>
   );

--- a/src/utils/pdf_util.ts
+++ b/src/utils/pdf_util.ts
@@ -1,6 +1,6 @@
 import { PDFDocument, PDFForm } from 'pdf-lib';
 import { toast } from 'sonner';
-import { FormType } from '../db/schema/form_submissions.schema';
+import { FormSubmission } from '../db/schema/form_submissions.schema';
 import {
   advanceDirectivesFormPdf,
   conductionRefusalFormPdf,
@@ -9,13 +9,23 @@ import {
   operationCensusRecordsFormPdf,
   refusalForTreatmentOrTransportFormPdf,
 } from './pdf_forms';
+import { fetchReferenceForm } from '../actions/form_submissions.action';
 
 export const generatePdf = async (
-  form: FormType,
-  data: any,
+  form: FormSubmission,
   returnBuffer: boolean = false
 ) => {
-  switch (form) {
+  const data = await fetchReferenceForm(form.form_type, form.reference_id);
+  
+  if (!data) {
+    toast.error('Failed to fetch form data', {
+      description: 'The form data could not be retrieved.',
+      richColors: true,
+    });
+    return;
+  }
+
+  switch (form.form_type) {
     case 'hospital_trip_tickets':
       return await hospitalTripTicketsPdf(data, returnBuffer);
     case 'dispatch_forms':


### PR DESCRIPTION
refactor fetching code for forms, actions on forms, to improve performance overall.

**previous** setup fetch all data and populate the referenced form data for each form while fetch.

**current** setup is fetch only what's needed and then fetch the data on-demand only (which is for each actions)

pagination stays the same. (fetching all data)